### PR TITLE
Exposes the scope property from the token request

### DIFF
--- a/lib/warden/github/oauth.rb
+++ b/lib/warden/github/oauth.rb
@@ -45,7 +45,7 @@ module Warden
         request.body = access_token_uri.query
 
         response = http.request(request)
-        decode_params(response.body).fetch('access_token')
+        decode_params(response.body)
       rescue IndexError
         fail BadVerificationCode, 'Bad verification code'
       end

--- a/lib/warden/github/strategy.rb
+++ b/lib/warden/github/strategy.rb
@@ -81,7 +81,8 @@ module Warden
       end
 
       def load_user
-        User.load(oauth.access_token, custom_session['browser_session_id'])
+        access_token = oauth.access_token
+        User.load(access_token['access_token'], access_token['scope'], custom_session['browser_session_id'])
       rescue OAuth::BadVerificationCode => e
         abort_flow!(e.message)
       end

--- a/lib/warden/github/user.rb
+++ b/lib/warden/github/user.rb
@@ -1,9 +1,9 @@
 module Warden
   module GitHub
-    class User < Struct.new(:attribs, :token, :browser_session_id, :memberships)
+    class User < Struct.new(:attribs, :token, :scope, :browser_session_id, :memberships)
       ATTRIBUTES = %w[id login name gravatar_id avatar_url email company site_admin].freeze
 
-      def self.load(access_token, browser_session_id = nil)
+      def self.load(access_token, scope, browser_session_id = nil)
         api  = Octokit::Client.new(:access_token => access_token)
         data =  { }
 
@@ -11,7 +11,7 @@ module Warden
           data[k.to_s] = v if ATTRIBUTES.include?(k.to_s)
         end
 
-        new(data, access_token, browser_session_id)
+        new(data, access_token, scope, browser_session_id)
       end
 
       def marshal_dump


### PR DESCRIPTION
the GH API returns the granted scopes associated with
the oauth token requested. This is useful for complicated
authenication flows where you need to progressively request
additional permissions, such as public vs private repository
access.
