### PR TITLE
Add oauth.token_response and revert breaking change

### DIFF
--- a/lib/warden/github/oauth.rb
+++ b/lib/warden/github/oauth.rb
@@ -32,12 +32,16 @@ module Warden
       end
 
       def access_token
-        @access_token ||= load_access_token
+        token_response['access_token']
+      end
+
+      def token_response
+        @token_response ||= load_token_response
       end
 
       private
 
-      def load_access_token
+      def load_token_response
         http = Net::HTTP.new(access_token_uri.host, access_token_uri.port)
         http.use_ssl = access_token_uri.scheme == 'https'
 

--- a/lib/warden/github/strategy.rb
+++ b/lib/warden/github/strategy.rb
@@ -81,8 +81,8 @@ module Warden
       end
 
       def load_user
-        access_token = oauth.access_token
-        User.load(access_token['access_token'], access_token['scope'], custom_session['browser_session_id'])
+        token_response = oauth.token_response
+        User.load(token_response['access_token'], token_response['scope'], custom_session['browser_session_id'])
       rescue OAuth::BadVerificationCode => e
         abort_flow!(e.message)
       end


### PR DESCRIPTION
Rather than change the behavior of `oauth.access_token`, how about an additive change?

/cc @rauhryan 
